### PR TITLE
docs: add example llm_functions config for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# AisSembly IDE
+
+This repository includes an example configuration for connecting to an [Ollama](https://ollama.ai) instance using `llm_functions.json`.
+
+## Connecting to Ollama
+
+Create an `llm_functions.json` file with the provider set to `ollama`, pointing to the Ollama server and specifying the model to use. For example:
+
+```json
+{
+  "llm": {
+    "provider": "ollama",
+    "endpoint": "http://localhost:11434",
+    "model": "llama2"
+  }
+}
+```
+
+A fuller example including a function definition is available at [`examples/ollama/llm_functions.json`](examples/ollama/llm_functions.json).

--- a/examples/ollama/llm_functions.json
+++ b/examples/ollama/llm_functions.json
@@ -1,0 +1,18 @@
+{
+  "llm": {
+    "provider": "ollama",
+    "endpoint": "http://localhost:11434",
+    "model": "llama2"
+  },
+  "functions": [
+    {
+      "name": "getTime",
+      "description": "Returns the current server time",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document how to configure `llm_functions.json` for an Ollama server
- provide sample `llm_functions.json` with a placeholder function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50d5fc7b8832999db1242bae2e623